### PR TITLE
Pin python version to ensure others get right version

### DIFF
--- a/c19-backend/Dockerfile
+++ b/c19-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
I'm using the walrus operator so Python < 3.8 is no use to anyone